### PR TITLE
Update TypeScript configuration.

### DIFF
--- a/test/shared/sampleApplication/tsconfig.json
+++ b/test/shared/sampleApplication/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "ES2018"
+      "ES2020"
     ],
     "module": "esnext",
     "moduleResolution": "node",

--- a/test/shared/sampleApplication/tsconfig.json
+++ b/test/shared/sampleApplication/tsconfig.json
@@ -6,14 +6,14 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext"
+      "ES2018"
     ],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
     "resolveJsonModule": true,
     "strict": true,
-    "target": "esnext",
+    "target": "ES2020",
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "declaration": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": [ "dom", "esnext" ],
-    "module": "commonjs",
+    "lib": [ "dom", "ES2018" ],
+    "module": "CommonJS",
     "outDir": "build",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "esnext"
+    "target": "ES2020"
   },
   "include": [
     "./**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": [ "dom", "ES2018" ],
+    "lib": [ "dom", "ES2020" ],
     "module": "CommonJS",
     "outDir": "build",
     "resolveJsonModule": true,


### PR DESCRIPTION
Hi @vaalllaa 👋 

@yeldiRium and I figured out that using `ESNext` is a problem, as the result of the TypeScript compiler may be code that actually does not run in modern browsers. It's obvious, but we didn't think of it in the first place.

Hence, here's an updated TypeScript configuration.

Can you please review, squash and merge it, if you are fine with it?