### PR TITLE
fix: Make anchor links change the URL.

### DIFF
--- a/lib/components/input/Link/Documentation.tsx
+++ b/lib/components/input/Link/Documentation.tsx
@@ -20,6 +20,23 @@ const Documentation = (): ReactElement => (
       </Link>
     </ComponentPreview>
 
+    <Headline level='2'>Anchor links</Headline>
+
+    <Paragraph>
+      When linking to anchors on the current page, the <code>Link</code> component
+      will smooth scroll to the target.
+    </Paragraph>
+
+    <ComponentPreview>
+      <Link
+        href='#intercepting-click-events'
+      >
+        This a link to #intercepting-click-events
+      </Link>
+    </ComponentPreview>
+
+    <Headline level='2'>Intercepting click events</Headline>
+
     <Headline level='2'>External links</Headline>
 
     <Paragraph>

--- a/lib/components/input/Link/Documentation.tsx
+++ b/lib/components/input/Link/Documentation.tsx
@@ -37,8 +37,6 @@ const Documentation = (): ReactElement => (
 
     <Headline level='2'>Intercepting click events</Headline>
 
-    <Headline level='2'>External links</Headline>
-
     <Paragraph>
       When linking to external websites, the <code>rel</code> and <code>target</code> attributes
       will be set automatically, so that external links will open in a new tab.

--- a/lib/components/navigation/PageNavigation/index.tsx
+++ b/lib/components/navigation/PageNavigation/index.tsx
@@ -3,9 +3,7 @@ import { Page } from './Page';
 import { PageGroup } from './PageGroup';
 import { PageSearch } from '../PageTree/PageSearch';
 import { SearchResults } from './SearchResults';
-import {
-  HorizontalBar, PageTree, PageTreeItemWithMetadata, TextBox, Theme
-} from '../../..';
+import { HorizontalBar, Icon, PageTree, PageTreeItemWithMetadata, TextBox, Theme } from '../../..';
 import { PageNavigationClassNames, styles } from './styles';
 import React, { ChangeEvent, FunctionComponent, ReactElement, ReactNode, useEffect, useState } from 'react';
 
@@ -96,6 +94,7 @@ const PageNavigation: FunctionComponent<PageNavigationProps> = ({
         showSearchBar ?
           (
             <HorizontalBar className={ classes.SearchBar }>
+              <Icon className={ classes.SearchBarIcon } name='search' size='sm' color='current' />
               <TextBox
                 className={ classes.SearchField }
                 value={ query }

--- a/lib/components/navigation/PageNavigation/styles.ts
+++ b/lib/components/navigation/PageNavigation/styles.ts
@@ -3,6 +3,7 @@ import { ComponentClassNames, Theme } from '../../..';
 export type PageNavigationClassNames =
   'PageNavigation' |
   'SearchBar' |
+  'SearchBarIcon' |
   'SearchField' |
   'Content';
 
@@ -12,21 +13,42 @@ const getStyles = (theme: Theme): ComponentClassNames<PageNavigationClassNames> 
     width: '100%',
     height: '100%',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+
+    '& $SearchBarIcon': {
+      position: 'absolute',
+      left: `${theme.space(3)}px`,
+      pointerEvents: 'none'
+    },
+
+    '& $SearchField': {
+      padding: `${theme.space(1)}px ${theme.space(1)}px`,
+      paddingLeft: `${theme.space(4)}px`,
+      flexGrow: 1
+    },
+
+    '& $Content': {
+      flexGrow: 1,
+      overflow: 'auto',
+      '-webkit-overflow-scrolling': 'touch',
+      paddingTop: theme.space(1.5)
+    }
   },
 
   SearchBar: {},
 
-  SearchField: {
-    padding: `${theme.space(0.5)}px ${theme.space(1)}px`,
-    flexGrow: 1
-  },
+  SearchBarIcon: {},
 
-  Content: {
-    flexGrow: 1,
-    overflow: 'auto',
-    '-webkit-overflow-scrolling': 'touch',
-    paddingTop: theme.space(1.5)
+  SearchField: {},
+
+  Content: {},
+
+  [theme.breakpoints.down('xs')]: {
+    PageNavigation: {
+      '& $SearchField': {
+        marginRight: theme.space(5)
+      }
+    }
   }
 });
 

--- a/lib/components/navigation/PageTree/index.ts
+++ b/lib/components/navigation/PageTree/index.ts
@@ -42,7 +42,8 @@ class PageTree {
         path: `${path}/${slug}`,
         breadcrumbs: breadcrumbsForItem,
         breadcrumbsAsString,
-        keywordsAsString
+        keywordsAsString,
+        keywords: item.keywords
       };
     });
 

--- a/lib/utils/scrollToAnchor.ts
+++ b/lib/utils/scrollToAnchor.ts
@@ -13,9 +13,11 @@ const scrollToAnchor = function (event: MouseEvent<HTMLElement>): void {
     return;
   }
 
-  event.preventDefault();
+  window.history.pushState(null, '', href);
 
   targetToScrollTo.scrollIntoView({ behavior: 'smooth' });
+
+  event.preventDefault();
 };
 
 export { scrollToAnchor };

--- a/styleguide/layouts/Styleguide/index.tsx
+++ b/styleguide/layouts/Styleguide/index.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import { navigation } from '../../configuration/navigation';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
@@ -27,7 +28,14 @@ import { StyleguideClassNames, styles } from './styles';
 
 const useStyles = createUseStyles<Theme, StyleguideClassNames>(styles);
 
-const Styleguide: FunctionComponent = ({ children }): ReactElement | null => {
+interface StyleguideProps {
+  pageTitle?: string;
+}
+
+const Styleguide: FunctionComponent<StyleguideProps> = ({
+  pageTitle,
+  children
+}): ReactElement | null => {
   const router = useRouter();
   const classes = useStyles();
   const device = useDevice();
@@ -74,6 +82,15 @@ const Styleguide: FunctionComponent = ({ children }): ReactElement | null => {
 
   return (
     <div className={ componentClasses }>
+      <Head>
+        {
+          pageTitle ?
+            <title>the native web ux | { pageTitle }</title> :
+            <title>the native web ux</title>
+        }
+        <link key='favicon' rel='icon' href='/favicon.png' type='image/png' />
+        <meta key='viewport' name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover' />
+      </Head>
       <div className={ classes.NavigationForDesktop }>
         <Sidebar>
           <NextLink href={ basePath }>

--- a/styleguide/layouts/Styleguide/index.tsx
+++ b/styleguide/layouts/Styleguide/index.tsx
@@ -55,7 +55,7 @@ const Styleguide: FunctionComponent<StyleguideProps> = ({
 
   const [ isNavigationVisible, setIsNavigationVisible ] = useState(true);
   const [ isSearchVisible, setIsSearchVisible ] = useState(false);
-  const [ activePath, setActivePath ] = useState(router.asPath);
+  const [ activePath, setActivePath ] = useState(router.pathname);
 
   const currentPage = pageTree.getPageItemByPath(activePath);
 

--- a/styleguide/layouts/Styleguide/index.tsx
+++ b/styleguide/layouts/Styleguide/index.tsx
@@ -4,7 +4,6 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import {
   Breadcrumbs,
-  Button,
   classNames,
   createUseStyles,
   Footer,
@@ -54,7 +53,6 @@ const Styleguide: FunctionComponent<StyleguideProps> = ({
   const isMobile = device === 'xs';
 
   const [ isNavigationVisible, setIsNavigationVisible ] = useState(true);
-  const [ isSearchVisible, setIsSearchVisible ] = useState(false);
   const [ activePath, setActivePath ] = useState(router.pathname);
 
   const currentPage = pageTree.getPageItemByPath(activePath);
@@ -128,11 +126,6 @@ const Styleguide: FunctionComponent<StyleguideProps> = ({
 
       <div className={ classes.NavigationUniversal }>
         <PageNavigation
-          header={
-            <HorizontalBar align='space-between' paddingHorizontal='none'>
-              <Button icon='search' onClick={ (): void => setIsSearchVisible(!isSearchVisible) } iconSize='sm' style={{ padding: 16 }} />
-            </HorizontalBar>
-          }
           nonIdealState={
             <NonIdealState cause='Sorry, no pages found.'>
               <p>
@@ -141,7 +134,7 @@ const Styleguide: FunctionComponent<StyleguideProps> = ({
             </NonIdealState>
           }
           pageTree={ pageTree }
-          showSearchBar={ isSearchVisible }
+          showSearchBar={ true }
           activePath={ activePath }
         />
       </div>


### PR DESCRIPTION
We should test this also on mobile devices. Please note: smooth scrolling is currently not supported in Safari. But at least anchor links should work on mobile Safari.