### PR TITLE
feat: Add tabIndex for Link component

### DIFF
--- a/lib/components/input/Link/index.tsx
+++ b/lib/components/input/Link/index.tsx
@@ -9,6 +9,7 @@ interface LinkProps {
   href: string;
   id?: string;
   style?: CSSProperties;
+  tabIndex?: number;
   onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
   onMouseOver?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
@@ -21,6 +22,7 @@ const Link: FunctionComponent<LinkProps> = React.forwardRef(({
   children,
   href,
   style,
+  tabIndex,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onClick,
   onMouseOver
@@ -38,6 +40,7 @@ const Link: FunctionComponent<LinkProps> = React.forwardRef(({
   const anchorProps = {
     id,
     style,
+    tabIndex,
     href,
     className: linkClasses,
     target,

--- a/test/unit/input/LinkTests.tsx
+++ b/test/unit/input/LinkTests.tsx
@@ -106,4 +106,21 @@ suite('Link', (): void => {
 
     assert.that(hovered).is.true();
   });
+
+  test('sets tabIndex on inner a element if tabIndex is provided.', async (): Promise<void> => {
+    const tabIndex = 0;
+
+    act((): void => {
+      ReactDOM.render(
+        <ThemeProvider>
+          <Link tabIndex={ tabIndex } id='link' href='/linkTo'>This is a link.</Link>
+        </ThemeProvider>,
+        container
+      );
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>('#link');
+
+    assert.that(link!.tabIndex).is.equalTo(tabIndex);
+  });
 });


### PR DESCRIPTION
As discussed in #729 this adds support for tabIndex on the needed component.