### PR TITLE
fix: getPage can't fetch from twitter without browser user-agent

### DIFF
--- a/lib/cli/verifyLinks/getPage.ts
+++ b/lib/cli/verifyLinks/getPage.ts
@@ -17,7 +17,11 @@ const getPage = async ({ url }: {
       // are a bot, not a browser (actually, we *are* a bot, but we want to be
       // treated like a browser). E.g., this makes a difference when accessing
       // GitHub. So, to get the desired behavior, accept anything.
-      accept: '*/*'
+      accept: '*/*',
+      // Twitter stopped serving to axios, based on its user agent.
+      // We use a browser-style user agent here to trick twitter into
+      // serving us anyway.
+      'user-agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'
     }
   });
 

--- a/lib/cli/verifyLinks/getPage.ts
+++ b/lib/cli/verifyLinks/getPage.ts
@@ -18,6 +18,7 @@ const getPage = async ({ url }: {
       // treated like a browser). E.g., this makes a difference when accessing
       // GitHub. So, to get the desired behavior, accept anything.
       accept: '*/*',
+
       // Twitter stopped serving to axios, based on its user agent.
       // We use a browser-style user agent here to trick twitter into
       // serving us anyway.

--- a/lib/cli/verifyLinks/getPage.ts
+++ b/lib/cli/verifyLinks/getPage.ts
@@ -19,9 +19,8 @@ const getPage = async ({ url }: {
       // GitHub. So, to get the desired behavior, accept anything.
       accept: '*/*',
 
-      // Twitter stopped serving to axios, based on its user agent.
-      // We use a browser-style user agent here to trick twitter into
-      // serving us anyway.
+      // Twitter stopped serving to axios, based on its user agent. We use a
+      // browser-style user agent here to trick Twitter into serving us anyway.
       'user-agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'
     }
   });

--- a/test/cli/getPageTests.ts
+++ b/test/cli/getPageTests.ts
@@ -1,0 +1,10 @@
+import { assert } from 'assertthat';
+import { getPage } from 'lib/cli/verifyLinks/getPage';
+
+suite('getPage', (): void => {
+  test('is able to fetch from twitter.', async (): Promise<void> => {
+    await assert.that(async (): Promise<void> => {
+      await getPage({ url: 'https://twitter.com/twitter' });
+    }).is.not.throwingAsync();
+  });
+});

--- a/test/cli/getPageTests.ts
+++ b/test/cli/getPageTests.ts
@@ -1,5 +1,5 @@
 import { assert } from 'assertthat';
-import { getPage } from 'lib/cli/verifyLinks/getPage';
+import { getPage } from '../../lib/cli/verifyLinks/getPage';
 
 suite('getPage', (): void => {
   test('is able to fetch from Twitter.', async (): Promise<void> => {

--- a/test/cli/getPageTests.ts
+++ b/test/cli/getPageTests.ts
@@ -2,7 +2,7 @@ import { assert } from 'assertthat';
 import { getPage } from 'lib/cli/verifyLinks/getPage';
 
 suite('getPage', (): void => {
-  test('is able to fetch from twitter.', async (): Promise<void> => {
+  test('is able to fetch from Twitter.', async (): Promise<void> => {
     await assert.that(async (): Promise<void> => {
       await getPage({ url: 'https://twitter.com/twitter' });
     }).is.not.throwingAsync();


### PR DESCRIPTION
This fixes an issue where Twitter apparently implemented some countermeasures to bots, which broke our link validation. Now, a user agent is added to the request when fetching from a link's URL, bypassing these countermeasures.